### PR TITLE
populate url and title

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,6 +51,10 @@ SimpleReach.prototype.loaded = function() {
  * @api public
  */
 
-SimpleReach.prototype.page = function() {
+SimpleReach.prototype.page = function(page) {
+  defaults(window.__reach_config, {
+    url: page.url(),
+    title: page.title()
+  });
   window.SPR.collect(window.__reach_config);
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -90,9 +90,24 @@ describe('Simplereach', function() {
       analytics.initialize();
       analytics.page();
     });
+
     it('SimpleReach SPR should exist', function() {
       analytics.page({ path: '/path', title: 'title' });
       analytics.assert(typeof window.SPR.collect === 'function');
+    });
+
+    describe('#page', function() {
+      beforeEach(function() {
+        analytics.stub(window.SPR, 'collect');
+      });
+
+      it('should send a page view', function() {
+        var title = document.title;
+        analytics.page();
+        analytics.equal(window.__reach_config.url, 'http://mygreatreachtestsite.com/ogurl.html');
+        analytics.equal(window.__reach_config.title, title);
+        analytics.called(window.SPR.collect);
+      });
     });
   });
 });


### PR DESCRIPTION
@andremalan lots of our customers do not have `canonical` on all their pages, and those that don't will see this error in their console whenever `page` triggers a call to `SPR.collect`

```
SPR-ERROR: 100 - Missing url
```

this fix will grab the url from the page call (which does respect canonical then falls back to the current URL) and stick it on the config object (if it's empty) prior to attempting to flush the call. make sense?