### PR TITLE
override default url property (false)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,5 +56,10 @@ SimpleReach.prototype.page = function(page) {
     url: page.url(),
     title: page.title()
   });
+
+  if (window.__reach_config.url === false) {
+    window.__reach_config.url = page.url();
+  }
+
   window.SPR.collect(window.__reach_config);
 };


### PR DESCRIPTION
If there is no `canonical` meta tag setup on a page, upon initializing the reach library the url property on the config object will automatically be set to `false`. So trying to set it via `defaults` is insufficient. This PR checks for that case and overrides with the actual URL.