### PR TITLE
add track function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,7 @@ SimpleReach.prototype.track = function(track) {
   var revenue = track.revenue();
   var orderId = track.orderId();
 
-  if (typeof(revenue) === 'number' && orderId) {
+  if (typeof revenue === 'number' && orderId) {
     window.SPR.collect({
       pid: this.options.pid,
       reach_tracking: false,

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,12 +76,12 @@ SimpleReach.prototype.track = function(track) {
   var revenue = track.revenue();
   var orderId = track.orderId();
 
-  if (revenue && orderId) {
+  if (typeof(revenue) === 'number' && orderId) {
     window.SPR.collect({
       pid: this.options.pid,
       reach_tracking: false,
-      url: track.url(),
-      title: track.title(),
+      url: track.proxy('context.page.url'),
+      title: track.proxy('context.page.title'),
       ctx_revenue: revenue,
       ctx_order_id: orderId
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,3 +63,27 @@ SimpleReach.prototype.page = function(page) {
 
   window.SPR.collect(window.__reach_config);
 };
+
+/**
+ * Page.
+ *
+ * http://www.simplereach.com/docs/ajax/
+ *
+ * @api public
+ */
+
+SimpleReach.prototype.track = function(track) {
+  var revenue = track.revenue();
+  var orderId = track.orderId();
+
+  if (revenue && orderId) {
+    window.SPR.collect({
+      pid: this.options.pid,
+      reach_tracking: false,
+      url: track.url(),
+      title: track.title(),
+      ctx_revenue: revenue,
+      ctx_order_id: orderId
+    });
+  }
+};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -135,7 +135,7 @@ describe('Simplereach', function() {
           ctx_order_id: orderId
         });
       });
-      it('should send collect when the order id is missing', function() {
+      it('should not send collect when the order id is missing', function() {
         var revenue = 25;
 
         analytics.track('Completed Order', {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -109,6 +109,42 @@ describe('Simplereach', function() {
         analytics.called(window.SPR.collect);
       });
     });
+
+    describe('#track', function() {
+      beforeEach(function() {
+        analytics.stub(window.SPR, 'collect');
+      });
+
+      it('should send collect when there is revenue and an order ID', function() {
+        var title = document.title;
+        var orderId = '50314b8e9bcf000000000000';
+        var revenue = 25;
+
+        analytics.track('Completed Order', {
+          orderId: orderId,
+          revenue: revenue,
+          title: title
+        });
+
+        analytics.called(window.SPR.collect, {
+          pid: options.pid,
+          reach_tracking: false,
+          url: 'http://mygreatreachtestsite.com/ogurl.html',
+          title: title,
+          ctx_revenue: revenue,
+          ctx_order_id: orderId
+        });
+      });
+      it('should send collect when the order id is missing', function() {
+        var revenue = 25;
+
+        analytics.track('Completed Order', {
+          revenue: revenue
+        });
+
+        analytics.didNotCall(window.SPR.collect);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Hey @ndhoule 

This is to allow for SimpleReach to track conversions that are done using the standard Segment conversion API.

I'm having a bit of trouble getting the tests to pass, it seems to be something with the load order. Do you mind taking a look?